### PR TITLE
Implement option to switch between conversion_async and gtag

### DIFF
--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -185,20 +185,26 @@
         }
 
         // gtag Events
-        function generateGtagEvent(mPEvent, conversionLabel, customProps) {
-            var conversionPayload = {
-                'send-to': gtagSiteId + '/' + conversionLabel
-            };
+        function getBaseGtagEvent(conversionLabel) {
+            return {
+                'send-to': gtagSiteId + '/' + conversionLabel,
+                'value': 0,
+                'language': 'en',
+                'remarketing_only': forwarderSettings.remarketingOnly == 'True'
+            }
+        }
 
+        function generateGtagEvent(mPEvent, conversionLabel, customProps) {
+            if (!conversionLabel) { return };
+
+            var conversionPayload = getBaseGtagEvent(conversionLabel);
             return mergeObjects(conversionPayload, customProps);
         }
 
         function generateGtagCommerceEvent(mPEvent, conversionLabel, customProps) {
-            var conversionPayload = {
-                'send-to': gtagSiteId + '/' + conversionLabel
-            };
+            if (!conversionLabel) { return };
 
-            var customProps = getCustomProps(mPEvent, isPageEvent);
+            var conversionPayload = getBaseGtagEvent(conversionLabel);
 
             if (mPEvent.ProductAction.ProductActionType === mParticle.ProductActionType.Purchase
                 && mPEvent.ProductAction.TransactionId) {

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -109,18 +109,6 @@
             return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
         }
 
-        // Converts an mParticle Event into either Legacy or gtag Event
-        function generateEvent(mPEvent, conversionLabel, isPageEvent) {
-            if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                return generateGtagEvent(mPEvent, conversionLabel, isPageEvent);
-            } else if (window.google_trackConversion) {
-                return generateAdwordsEvent(mPEvent, conversionLabel, isPageEvent);
-            } else {
-                console.error('Unrecognized Event', mPEvent);
-                return false;
-            }
-        }
-
         // Converts an mParticle Commerce Event into either Legacy or gtag Event
         function generateCommerceEvent(mPEvent, conversionLabel, isPageEvent) {
             if (mPEvent.ProductAction
@@ -195,14 +183,14 @@
         }
 
         function generateGtagEvent(mPEvent, conversionLabel, customProps) {
-            if (!conversionLabel) { return };
+            if (!conversionLabel) { return null; };
 
             var conversionPayload = getBaseGtagEvent(conversionLabel);
             return mergeObjects(conversionPayload, customProps);
         }
 
         function generateGtagCommerceEvent(mPEvent, conversionLabel, customProps) {
-            if (!conversionLabel) { return };
+            if (!conversionLabel) { return null; };
 
             var conversionPayload = getBaseGtagEvent(conversionLabel);
 

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -56,10 +56,13 @@
                         sendEventFunction = sendGtagEvent;
                         generateEventFunction = generateGtagEvent;
                         generateCommerceEvent = generateGtagCommerceEvent;
+
                     } else if (window.google_trackConversion) {
-                        sendEventFunction = sendLegacyEvent;
+                        // window.google_trackConversion is a legacy API and will be deprecated
+                        sendEventFunction = sendAdwordsEvent;
                         generateEventFunction = generateAdwordsEvent;
                         generateCommerceEvent = generateAdwordsCommerceEvent;
+
                     } else {
                         eventQueue.push({
                             action: processEvent,
@@ -217,17 +220,17 @@
             try {
                 gtag('event', 'conversion', payload);
             } catch (e) {
-                console.error('gtag is not available to send payload', payload);
+                console.error('gtag is not available to send payload: ', payload, e);
                 return false;
             }
             return true;
         }
 
-        function sendLegacyEvent(payload) {
+        function sendAdwordsEvent(payload) {
             try {
                 window.google_trackConversion(payload);
             } catch (e) {
-                console.error('google_trackConversion is not available to send payload', payload);
+                console.error('google_trackConversion is not available to send payload: ', payload, e);
                 return false;
             }
             return true;
@@ -387,18 +390,8 @@
             }
         }
 
-        function purgeQueue(queue) {
-            if (queue.length) {
-                queue.forEach(function (action, data) {
-                    action(data);
-                });
-                queue = [];
-            }
-        }
-
         this.init = initForwarder;
         this.process = processEvent;
-        this.purgeQueue = purgeQueue;
         this.processQueue = processQueue;
     };
 

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 
         window.mParticle = new mp();
     </script>
-    <script src="../GoogleAdWordsEventForwarder.js" data-cover></script>
+    <script src="../dist/GoogleAdWordsEventForwarder.iife.js" data-cover></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -656,7 +656,6 @@ describe('Adwords forwarder', function () {
                     'conversion',
                     {
                         'send-to': 'AW-123123123/pageViewLabel123',
-                        action: 'code',
                         title: 'my page title'
                     }
                 ];
@@ -706,7 +705,6 @@ describe('Adwords forwarder', function () {
                     'conversion',
                     {
                         'send-to': 'AW-123123123/commerceLabel123',
-                        action: 'code',
                         sale: 'seasonal sale'
                     }
                 ];

--- a/test/tests.js
+++ b/test/tests.js
@@ -660,8 +660,6 @@ describe('Adwords forwarder', function () {
                     }
                 ];
 
-                // debugger;
-
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
                 window.dataLayer.should.matchAny(expectedDataLayer);

--- a/test/tests.js
+++ b/test/tests.js
@@ -705,7 +705,11 @@ describe('Adwords forwarder', function () {
                     'conversion',
                     {
                         'send-to': 'AW-123123123/commerceLabel123',
-                        sale: 'seasonal sale'
+                        currency: 'USD',
+                        language: 'en',
+                        remarketing_only: false,
+                        sale: 'seasonal sale',
+                        value: 450
                     }
                 ];
 
@@ -739,8 +743,11 @@ describe('Adwords forwarder', function () {
                     }
                 });
 
+                // debugger;
+
                 failMessage.should.not.be.null();
                 failMessage.should.be.containEql("Can't send to forwarder")
+                window.dataLayer.length.should.eql(0)
                 done();
             });
         });
@@ -771,6 +778,7 @@ describe('Adwords forwarder', function () {
 
                 failMessage.should.not.be.null();
                 failMessage.should.be.containEql("Can't send to forwarder")
+                window.dataLayer.length.should.eql(0)
                 done();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -115,232 +115,543 @@ describe('Adwords forwarder', function () {
         window.google_track_data.should.have.property("google_conversion_id", 'AW-123123123')
     }
 
-    describe("Page View Conversion Label", function () {
-        before(function () {
+    describe('Legacy Conversion Async', function () {
+        describe("Page View Conversion Label", function () {
+            before(function () {
 
-            var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
 
-            mParticle.forwarder.init({
-                labels: JSON.stringify(map),
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should have conversion labels for page view', function (done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageView,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock'
+                    }
+                });
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_conversion_label', "pageViewLabel123");
+
+                done();
+            });
+        });
+
+        describe("Page Event Conversion Label", function () {
+            before(function () {
+
+                var map = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" +  EventType.Navigation + 'Homepage') }]
+
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should have conversion labels for page event', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock'
+                    }
+                });
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_conversion_label', "pageEventLabel123");
+
+                done();
+            });
         });
 
 
-        it('should have conversion labels for page view', function (done) {
-            var successMessage = mParticle.forwarder.process({
-                EventName: 'Homepage',
-                EventDataType: MessageType.PageView,
-                EventAttributes: {
-                    showcase: 'something',
-                    test: 'thisoneshouldgetmapped',
-                    mp: 'rock'
-                }
+        describe("Commerce Event Conversion Label", function () {
+            before(function () {
+
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
+
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
             });
 
-            successMessage.should.not.be.null();
-            successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-            checkCommonProperties();
-            window.google_track_data.should.have.property('google_conversion_label', "pageViewLabel123");
+            it('should have conversion labels for commerce event', function (done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: "eCommerce - Purchase",
+                    EventDataType: MessageType.Commerce,
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1
+                            }
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: "USD"
+                });
 
-            done();
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_conversion_label', "commerceLabel123");
+
+                done();
+            });
+        })
+
+        describe("Custom Parameters", function () {
+            before(function () {
+
+                var labels = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') }]
+                var attr = [{ "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') }]
+
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(labels),
+                    customParameters: JSON.stringify(attr),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+            it('should have custom params for page event', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        attributekey: 'attributevalue'
+                    }
+                });
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_custom_params');
+                Object.keys(window.google_track_data.google_custom_params).length.should.be.equal(1);
+                window.google_track_data.google_custom_params.should.have.property('mycustomprop', 'attributevalue')
+                done();
+            });
+        });
+
+        describe("Unmapped conversion labels", function () {
+            before(function () {
+
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
+
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+            it('should not forward unmapped events', function (done) {
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+        });
+
+
+        describe("Bad Label Json", function () {
+            before(function () {
+                // The ids are calculated based on the events used in the tests below so they must match exactly.
+                mParticle.forwarder.init({
+                    labels: 'baaaaaddddddd json',
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should not forward with bad labels json', function (done) {
+
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+        });
+
+
+        describe("Bad Custom Parameters Json", function () {
+            before(function () {
+                // The ids are calculated based on the events used in the tests below so they must match exactly.
+                mParticle.forwarder.init({
+                    customParameters: 'sdpfuhasdflasdjfnsdjfsdjfn really baddd json',
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should not forward with bad custom parameters json', function (done) {
+
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
         });
     });
 
-    describe("Page Event Conversion Label", function () {
-        before(function () {
+    describe('GTAG Conversions', function () {
+        describe('Initializing GTAG', function () {
+            it('should disable gtag and dataLayer by default', function (done) {
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
 
-            var map = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" +  EventType.Navigation + 'Homepage') }]
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
 
-            mParticle.forwarder.init({
-                labels: JSON.stringify(map),
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-
-        it('should have conversion labels for page event', function (done) {
-
-            var successMessage = mParticle.forwarder.process({
-                EventName: 'Homepage',
-                EventDataType: MessageType.PageEvent,
-                EventCategory: EventType.Navigation,
-                EventAttributes: {
-                    showcase: 'something',
-                    test: 'thisoneshouldgetmapped',
-                    mp: 'rock'
-                }
+                (typeof window.gtag === 'undefined').should.be.true();
+                (typeof window.dataLayer === 'undefined').should.be.true();
+                done();
             });
 
-            successMessage.should.not.be.null();
-            successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-            checkCommonProperties();
-            window.google_track_data.should.have.property('google_conversion_label', "pageEventLabel123");
+            it('should initialize gtag and dataLayer when user opts in', function (done) {
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
 
-            done();
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    enableGtag: 'True',
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, 1, true);
+
+                window.gtag.should.be.ok();
+                window.dataLayer.should.be.ok();
+
+                done();
+            });
         });
+
+        describe("Page View Conversion Label", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
+
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: JSON.stringify(map),
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should have conversion labels for page view', function (done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageView,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock'
+                    }
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/pageViewLabel123'
+                    }
+                ];
+
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.match([expectedDataLayer]);
+
+                done();
+            });
+        });
+        describe("Page Event Conversion Label", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                var map = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" +  EventType.Navigation + 'Homepage') }]
+
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: JSON.stringify(map),
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should have conversion labels for page event', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock'
+                    }
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/pageEventLabel123'
+                    }
+                ];
+
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.match([expectedDataLayer]);
+
+                done();
+            });
+        });
+
+
+        describe("Commerce Event Conversion Label", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
+
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: JSON.stringify(map),
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+            it('should have conversion labels for commerce event', function (done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: "eCommerce - Purchase",
+                    EventDataType: MessageType.Commerce,
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1
+                            }
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: "USD"
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/commerceLabel123',
+                        order_id: 123,
+                        value: 450,
+                        currency: 'USD',
+                    }
+                ];
+
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.match([expectedDataLayer]);
+
+                done();
+            });
+        })
+
+        describe("Custom Parameters", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                var labels = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') }]
+                var attr = [{ "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') }]
+
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: JSON.stringify(labels),
+                    customParameters: JSON.stringify(attr),
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+            it('should have custom params for page event', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        attributekey: 'attributevalue'
+                    }
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/pageEventLabel123',
+                        mycustomprop: 'attributevalue'
+                    }
+                ];
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.match([expectedDataLayer]);
+
+                done();
+            });
+        });
+
+        describe("Unmapped conversion labels", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
+
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: JSON.stringify(map),
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+            it('should not forward unmapped events', function (done) {
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+        });
+
+
+        describe("Bad Label Json", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                // The ids are calculated based on the events used in the tests below so they must match exactly.
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    labels: 'baaaaaddddddd json',
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should not forward with bad labels json', function (done) {
+
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+        });
+
+
+        describe("Bad Custom Parameters Json", function () {
+            before(function () {
+                window.dataLayer = undefined;
+
+                // The ids are calculated based on the events used in the tests below so they must match exactly.
+                mParticle.forwarder.init({
+                    enableGtag: 'True',
+                    customParameters: 'sdpfuhasdflasdjfnsdjfsdjfn really baddd json',
+                    conversionId: '123123123'
+                }, reportService.cb, 1, true);
+            });
+
+
+            it('should not forward with bad custom parameters json', function (done) {
+
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'Something random',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        showcase: 'something'
+                    }
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+        });
+
     });
-
-
-    describe("Commerce Event Conversion Label", function () {
-        before(function () {
-
-            var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
-
-            mParticle.forwarder.init({
-                labels: JSON.stringify(map),
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-        it('should have conversion labels for commerce event', function (done) {
-            var successMessage = mParticle.forwarder.process({
-                EventName: "eCommerce - Purchase",
-                EventDataType: MessageType.Commerce,
-                ProductAction: {
-                    ProductActionType: ProductActionType.Purchase,
-                    ProductList: [
-                        {
-                            Sku: '12345',
-                            Name: 'iPhone 6',
-                            Category: 'Phones',
-                            Brand: 'iPhone',
-                            Variant: '6',
-                            Price: 400,
-                            CouponCode: null,
-                            Quantity: 1
-                        }
-                    ],
-                    TransactionId: 123,
-                    Affiliation: 'my-affiliation',
-                    TotalAmount: 450,
-                    TaxAmount: 40,
-                    ShippingAmount: 10,
-                },
-                CurrencyCode: "USD"
-            });
-
-            successMessage.should.not.be.null();
-            successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-            checkCommonProperties();
-            window.google_track_data.should.have.property('google_conversion_label', "commerceLabel123");
-
-            done();
-        });
-    })
-
-    describe("Custom Parameters", function () {
-        before(function () {
-
-            var labels = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') }]
-            var attr = [{ "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') }]
-
-            mParticle.forwarder.init({
-                labels: JSON.stringify(labels),
-                customParameters: JSON.stringify(attr),
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-        it('should have custom params for page event', function (done) {
-
-            var successMessage = mParticle.forwarder.process({
-                EventName: 'Homepage',
-                EventDataType: MessageType.PageEvent,
-                EventCategory: EventType.Navigation,
-                EventAttributes: {
-                    attributekey: 'attributevalue'
-                }
-            });
-
-            successMessage.should.not.be.null();
-            successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-            checkCommonProperties();
-            window.google_track_data.should.have.property('google_custom_params');
-            Object.keys(window.google_track_data.google_custom_params).length.should.be.equal(1);
-            window.google_track_data.google_custom_params.should.have.property('mycustomprop', 'attributevalue')
-            done();
-        });
-    });
-
-    describe("Unmapped conversion labels", function () {
-        before(function () {
-
-            var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
-
-            mParticle.forwarder.init({
-                labels: JSON.stringify(map),
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-        it('should not forward unmapped events', function (done) {
-            var failMessage = mParticle.forwarder.process({
-                EventName: 'Something random',
-                EventDataType: MessageType.Commerce,
-                EventAttributes: {
-                    showcase: 'something'
-                }
-            });
-
-            failMessage.should.not.be.null();
-            failMessage.should.be.containEql("Can't send to forwarder")
-            done();
-        });
-    });
-
-
-    describe("Bad Label Json", function () {
-        before(function () {
-            // The ids are calculated based on the events used in the tests below so they must match exactly.
-            mParticle.forwarder.init({
-                labels: 'baaaaaddddddd json',
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-
-        it('should not forward with bad labels json', function (done) {
-
-            var failMessage = mParticle.forwarder.process({
-                EventName: 'Something random',
-                EventDataType: MessageType.Commerce,
-                EventAttributes: {
-                    showcase: 'something'
-                }
-            });
-
-            failMessage.should.not.be.null();
-            failMessage.should.be.containEql("Can't send to forwarder")
-            done();
-        });
-    });
-
-
-    describe("Bad Custom Parameters Json", function () {
-        before(function () {
-            // The ids are calculated based on the events used in the tests below so they must match exactly.
-            mParticle.forwarder.init({
-                customParameters: 'sdpfuhasdflasdjfnsdjfsdjfn really baddd json',
-                conversionId: 'AW-123123123'
-            }, reportService.cb, 1, true);
-        });
-
-
-        it('should not forward with bad custom parameters json', function (done) {
-
-            var failMessage = mParticle.forwarder.process({
-                EventName: 'Something random',
-                EventDataType: MessageType.Commerce,
-                EventAttributes: {
-                    showcase: 'something'
-                }
-            });
-
-            failMessage.should.not.be.null();
-            failMessage.should.be.containEql("Can't send to forwarder")
-            done();
-        });
-    });
-
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -124,7 +124,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
 
@@ -156,7 +156,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
 
@@ -191,7 +191,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
             it('should have conversion labels for commerce event', function (done) {
@@ -233,14 +233,22 @@ describe('Adwords forwarder', function () {
         describe("Custom Parameters", function () {
             before(function () {
 
-                var labels = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') }]
-                var attr = [{ "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') }]
+                var labels = [
+                    { "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') },
+                    { "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') },
+                    { "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") },
+                ];
+                var attr = [
+                    { "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') },
+                    { "maptype": "EventAttributeClassDetails.Id", "value": "title", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'title') },
+                    { "maptype": "EventAttributeClassDetails.Id", "value": "sale", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + 'sale') }
+                ];
 
                 mParticle.forwarder.init({
                     labels: JSON.stringify(labels),
                     customParameters: JSON.stringify(attr),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
             it('should have custom params for page event', function (done) {
@@ -262,6 +270,65 @@ describe('Adwords forwarder', function () {
                 window.google_track_data.google_custom_params.should.have.property('mycustomprop', 'attributevalue')
                 done();
             });
+
+            it('should have custom params for page view', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageView,
+                    EventAttributes: {
+                        title: 'my page view'
+                    }
+                });
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_custom_params');
+                Object.keys(window.google_track_data.google_custom_params).length.should.be.equal(1);
+                window.google_track_data.google_custom_params.should.have.property('title', 'my page view');
+                done();
+            });
+
+            it('should have custom params for commerce events', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: "eCommerce - Purchase",
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        sale: 'seasonal sale'
+                    },
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1
+                            }
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: "USD"
+                });
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                checkCommonProperties();
+                window.google_track_data.should.have.property('google_custom_params');
+                Object.keys(window.google_track_data.google_custom_params).length.should.be.equal(1);
+                window.google_track_data.google_custom_params.should.have.property('sale', 'seasonal sale');
+                done();
+            });
         });
 
         describe("Unmapped conversion labels", function () {
@@ -272,7 +339,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
             it('should not forward unmapped events', function (done) {
@@ -297,7 +364,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: 'baaaaaddddddd json',
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
 
@@ -324,7 +391,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     customParameters: 'sdpfuhasdflasdjfnsdjfsdjfn really baddd json',
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
             });
 
 
@@ -353,7 +420,7 @@ describe('Adwords forwarder', function () {
                 mParticle.forwarder.init({
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
-                }, reportService.cb, 1, true);
+                }, reportService.cb, true, true);
 
                 (typeof window.gtag === 'undefined').should.be.true();
                 (typeof window.dataLayer === 'undefined').should.be.true();
@@ -417,6 +484,7 @@ describe('Adwords forwarder', function () {
                 done();
             });
         });
+
         describe("Page Event Conversion Label", function () {
             before(function () {
                 window.dataLayer = undefined;
@@ -526,8 +594,16 @@ describe('Adwords forwarder', function () {
             before(function () {
                 window.dataLayer = undefined;
 
-                var labels = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') }]
-                var attr = [{ "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') }]
+                var labels = [
+                    { "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') },
+                    { "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') },
+                    { "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") },
+                ];
+                var attr = [
+                    { "maptype": "EventAttributeClass.Id", "value": "mycustomprop", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'attributekey') },
+                    { "maptype": "EventAttributeClassDetails.Id", "value": "title", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'title') },
+                    { "maptype": "EventAttributeClassDetails.Id", "value": "sale", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + 'sale') }
+                ]
 
                 mParticle.forwarder.init({
                     enableGtag: 'True',
@@ -560,6 +636,84 @@ describe('Adwords forwarder', function () {
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
                 window.dataLayer.should.match([expectedDataLayer]);
+
+                done();
+            });
+
+            it('should have custom params for page view', function (done) {
+
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageView,
+                    EventAttributes: {
+                        title: 'my page title'
+                    }
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/pageViewLabel123',
+                        action: 'code',
+                        title: 'my page title'
+                    }
+                ];
+
+                // debugger;
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.matchAny(expectedDataLayer);
+
+                done();
+            });
+
+            it('should have custom params for commerce event', function (done) {
+
+                var successMessage = mParticle.forwarder.process({
+                    EventName: "eCommerce - Purchase",
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        sale: 'seasonal sale'
+                    },
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1
+                            }
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: "USD"
+                });
+
+                var expectedDataLayer = [
+                    'event',
+                    'conversion',
+                    {
+                        'send-to': 'AW-123123123/commerceLabel123',
+                        action: 'code',
+                        sale: 'seasonal sale'
+                    }
+                ];
+
+                successMessage.should.not.be.null();
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
+                window.dataLayer.should.matchAny(expectedDataLayer);
 
                 done();
             });


### PR DESCRIPTION
Google is pushing customers to start using Google Site Tags (gtag) for all analytic tracking. As Google is handling backwards compatibility themselves, we are offering our users a way to opt into gtag so that they can begin transitioning to the latest and greatest versions of Google Ads analytics.