### PR TITLE
fix: Prevent unmapped events from being forwarded

### DIFF
--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -76,21 +76,23 @@
                     var conversionLabel = getConversionLabel(event);
                     var customProps = getCustomProps(event);
 
-                    // Determines the proper event to fire
-                    if (event.EventDataType == MessageType.PageView || event.EventDataType == MessageType.PageEvent) {
-                        eventPayload = generateEventFunction(event, conversionLabel, customProps);
-                    } else if (event.EventDataType == MessageType.Commerce && event.ProductAction) {
-                        eventPayload = generateCommerceEvent(event, conversionLabel, customProps);
-                    }
-
-                    if (eventPayload) {
-                       reportEvent = sendEventFunction(eventPayload);
-                    }
-
-                    if (reportEvent && reportingService) {
-                        reportingService(self, event);
-
-                        return 'Successfully sent to ' + name;
+                    if (conversionLabel) {
+                        // Determines the proper event to fire
+                        if (event.EventDataType == MessageType.PageView || event.EventDataType == MessageType.PageEvent) {
+                            eventPayload = generateEventFunction(event, conversionLabel, customProps);
+                        } else if (event.EventDataType == MessageType.Commerce && event.ProductAction) {
+                            eventPayload = generateCommerceEvent(event, conversionLabel, customProps);
+                        }
+    
+                        if (eventPayload) {
+                           reportEvent = sendEventFunction(eventPayload);
+                        }
+    
+                        if (reportEvent && reportingService) {
+                            reportingService(self, event);
+    
+                            return 'Successfully sent to ' + name;
+                        }
                     }
 
                     return 'Can\'t send to forwarder: ' + name + '. Event not mapped';

--- a/test/tests.js
+++ b/test/tests.js
@@ -345,10 +345,10 @@ describe('Adwords forwarder', function () {
             it('should not forward unmapped events', function (done) {
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
-                        showcase: 'something'
-                    }
+                        showcase: 'something',
+                    },
                 });
 
                 failMessage.should.not.be.null();
@@ -735,13 +735,11 @@ describe('Adwords forwarder', function () {
             it('should not forward unmapped events', function (done) {
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
                         showcase: 'something'
                     }
                 });
-
-                // debugger;
 
                 failMessage.should.not.be.null();
                 failMessage.should.be.containEql("Can't send to forwarder")


### PR DESCRIPTION
If an event with `MessageType` of `PageView` of `PageEvent` is sent from the core SDK and is not mapped in a Google Ad words configuration, the currently logic still permits these events to be sent to Google's Adwords servers.  This PR fixes this.