### PR TITLE
feat: Add enhanced conversions

### DIFF
--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -28,7 +28,6 @@
         },
         ENHANCED_CONVERSION_DATA = "GoogleAds.ECData";
 
-
     var constructor = function () {
         var self = this,
             isInitialized = false,
@@ -220,6 +219,7 @@
             if (!conversionLabel) { return null; };
 
             var conversionPayload = getBaseGtagEvent(conversionLabel);
+            conversionPayload.transaction_id = mPEvent.SourceMessageId;
             return mergeObjects(conversionPayload, customProps);
         }
 
@@ -230,7 +230,9 @@
 
             if (mPEvent.ProductAction.ProductActionType === mParticle.ProductActionType.Purchase
                 && mPEvent.ProductAction.TransactionId) {
-                conversionPayload.order_id = mPEvent.ProductAction.TransactionId;
+                conversionPayload.transaction_id = mPEvent.ProductAction.TransactionId;
+            } else {
+                conversionPayload.transaction_id = mPEvent.SourceMessageId;
             }
 
             if (mPEvent.CurrencyCode) {

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -346,7 +346,6 @@
                 };
                 gTagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + gtagSiteId;
                 document.getElementsByTagName('head')[0].appendChild(gTagScript);
-                gtag()
             })();
         }
 

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -25,7 +25,8 @@
             CrashReport: 5,
             OptOut: 6,
             Commerce: 16
-        };
+        },
+        ENHANCED_CONVERSION_DATA = "GoogleAds.ECData";
 
 
     var constructor = function () {
@@ -53,6 +54,19 @@
 
                 try {
                     if (window.gtag && forwarderSettings.enableGtag == 'True') {
+                        if (event.CustomFlags && 
+                            Object.keys(event.CustomFlags).length &&
+                            event.CustomFlags[ENHANCED_CONVERSION_DATA]
+                        ) {
+                            if (forwarderSettings.enableEnhancedConversions === 'True') {
+                                setEnhancedConversionData(
+                                    event.CustomFlags[ENHANCED_CONVERSION_DATA]
+                                );
+                            } else {
+                                console.warn('You have a custom flag of enhanced conversions, but you have not enabled enhanced converisons');
+                            }
+                        }
+
                         sendEventFunction = sendGtagEvent;
                         generateEventFunction = generateGtagEvent;
                         generateCommerceEvent = generateGtagCommerceEvent;
@@ -111,6 +125,25 @@
             return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
         }
 
+        function setEnhancedConversionData(enhancedConversionData) {
+            if (enhancedConversionData.email) {
+                window.enhanced_conversion_data.email = enhancedConversionData.email;
+            }
+            if (enhancedConversionData.phone_number) {
+                window.enhanced_conversion_data.phone_number = enhancedConversionData.phone_number;
+            }
+            if (enhancedConversionData.first_name) {
+                window.enhanced_conversion_data.first_name = enhancedConversionData.first_name;
+            }
+            if (enhancedConversionData.last_name) {
+                window.enhanced_conversion_data.last_name = enhancedConversionData.last_name;
+            }
+            if (enhancedConversionData.home_address) {
+                window.enhanced_conversion_data.home_address =
+                    enhancedConversionData.home_address;
+            }
+        }
+
         // Converts an mParticle Commerce Event into either Legacy or gtag Event
         function generateCommerceEvent(mPEvent, conversionLabel, isPageEvent) {
             if (mPEvent.ProductAction
@@ -133,7 +166,6 @@
 
 
         // ** Adwords Events
-
         function getBaseAdWordEvent() {
             var adWordEvent = {};
             adWordEvent.google_conversion_value = 0;
@@ -300,12 +332,19 @@
                 gTagScript.async = true;
                 gTagScript.onload = function () {
                     gtag('js', new Date());
-                    gtag('config', gtagSiteId);
+                    if (forwarderSettings.enableEnhancedConversions === 'True') {
+                        gtag('config', gtagSiteId, {
+                            allow_enhanced_conversions: true
+                        });
+                    } else {
+                        gtag('config', gtagSiteId);
+                    }
                     isInitialized = true;
                     processQueue(eventQueue);
                 };
                 gTagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + gtagSiteId;
                 document.getElementsByTagName('head')[0].appendChild(gTagScript);
+                gtag()
             })();
         }
 
@@ -324,7 +363,7 @@
         }
 
         function initForwarder(settings, service, testMode) {
-
+            window.enhanced_conversion_data = {};
             forwarderSettings = settings;
             reportingService = service;
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -119,9 +119,9 @@ describe('Adwords forwarder', function () {
         beforeEach(function() {
             window.dataLayer = undefined;
         });
+
         describe("Page View Conversion Label", function () {
             before(function () {
-
                 var map = [{ "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') }]
 
                 mParticle.forwarder.init({
@@ -163,7 +163,6 @@ describe('Adwords forwarder', function () {
 
 
             it('should have conversion labels for page event', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageEvent,
@@ -187,7 +186,6 @@ describe('Adwords forwarder', function () {
 
         describe("Commerce Event Conversion Label", function () {
             before(function () {
-
                 var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
 
                 mParticle.forwarder.init({
@@ -234,7 +232,6 @@ describe('Adwords forwarder', function () {
 
         describe("Custom Parameters", function () {
             before(function () {
-
                 var labels = [
                     { "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" + EventType.Navigation + 'Homepage') },
                     { "maptype": "EventClassDetails.Id", "value": "pageViewLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageView + "" + 'Homepage') },
@@ -254,7 +251,6 @@ describe('Adwords forwarder', function () {
             });
 
             it('should have custom params for page event', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageEvent,
@@ -274,7 +270,6 @@ describe('Adwords forwarder', function () {
             });
 
             it('should have custom params for page view', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageView,
@@ -293,7 +288,6 @@ describe('Adwords forwarder', function () {
             });
 
             it('should have custom params for commerce events', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: "eCommerce - Purchase",
                     EventDataType: MessageType.Commerce,
@@ -335,7 +329,6 @@ describe('Adwords forwarder', function () {
 
         describe("Unmapped conversion labels", function () {
             before(function () {
-
                 var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
 
                 mParticle.forwarder.init({
@@ -359,7 +352,6 @@ describe('Adwords forwarder', function () {
             });
         });
 
-
         describe("Bad Label Json", function () {
             before(function () {
                 // The ids are calculated based on the events used in the tests below so they must match exactly.
@@ -371,10 +363,9 @@ describe('Adwords forwarder', function () {
 
 
             it('should not forward with bad labels json', function (done) {
-
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
                         showcase: 'something'
                     }
@@ -398,10 +389,9 @@ describe('Adwords forwarder', function () {
 
 
             it('should not forward with bad custom parameters json', function (done) {
-
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
                         showcase: 'something'
                     }
@@ -478,7 +468,6 @@ describe('Adwords forwarder', function () {
                     }
                 ];
 
-
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
                 window.dataLayer[1].should.match(result);
@@ -489,8 +478,6 @@ describe('Adwords forwarder', function () {
 
         describe("Page Event Conversion Label", function () {
             before(function () {
-                window.dataLayer = undefined;
-
                 var map = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" +  EventType.Navigation + 'Homepage') }]
 
                 mParticle.forwarder.init({
@@ -500,9 +487,7 @@ describe('Adwords forwarder', function () {
                 }, reportService.cb, 1, true);
             });
 
-
             it('should have conversion labels for page event', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageEvent,
@@ -522,7 +507,6 @@ describe('Adwords forwarder', function () {
                     }
                 ];
 
-
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
                 window.dataLayer[1].should.match(result);
@@ -530,7 +514,6 @@ describe('Adwords forwarder', function () {
                 done();
             });
         });
-
 
         describe("Commerce Event Conversion Label", function () {
             before(function () {
@@ -583,7 +566,6 @@ describe('Adwords forwarder', function () {
                     }
                 ];
 
-
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
                 window.dataLayer[1].should.match(result);
@@ -614,7 +596,8 @@ describe('Adwords forwarder', function () {
                     conversionId: '123123123'
                 }, reportService.cb, 1, true);
             });
-            this.afterEach(function() {
+
+            afterEach(function() {
                 window.dataLayer = [];
             });
 
@@ -737,7 +720,7 @@ describe('Adwords forwarder', function () {
                 window.dataLayer = [];
             })
 
-            it('should not forward unmapped events', function (done) {
+            it('should not forward unmapped custom events', function (done) {
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
                     EventDataType: MessageType.PageEvent,
@@ -752,7 +735,6 @@ describe('Adwords forwarder', function () {
                 done();
             });
         });
-
 
         describe("Bad Label Json", function () {
             before(function () {
@@ -769,10 +751,9 @@ describe('Adwords forwarder', function () {
             });
 
             it('should not forward with bad labels json', function (done) {
-
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
                         showcase: 'something'
                     }
@@ -801,10 +782,9 @@ describe('Adwords forwarder', function () {
 
 
             it('should not forward with bad custom parameters json', function (done) {
-
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
-                    EventDataType: MessageType.Commerce,
+                    EventDataType: MessageType.PageEvent,
                     EventAttributes: {
                         showcase: 'something'
                     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -335,9 +335,20 @@ describe('Adwords forwarder', function () {
                     labels: JSON.stringify(map),
                     conversionId: 'AW-123123123'
                 }, reportService.cb, true, true);
+            });before(function () {
+                var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
+
+                mParticle.forwarder.init({
+                    labels: JSON.stringify(map),
+                    conversionId: 'AW-123123123'
+                }, reportService.cb, true, true);
             });
 
-            it('should not forward unmapped events', function (done) {
+            beforeEach(function() {
+                window.dataLayer = [];
+            });
+
+            it('should not forward unmapped custom events', function (done) {
                 var failMessage = mParticle.forwarder.process({
                     EventName: 'Something random',
                     EventDataType: MessageType.PageEvent,
@@ -348,6 +359,42 @@ describe('Adwords forwarder', function () {
 
                 failMessage.should.not.be.null();
                 failMessage.should.be.containEql("Can't send to forwarder")
+                done();
+            });
+
+            it('should not forward unmapped ecommerce events', function(done) {
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'eCommerce - AddToCart',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        sale: 'seasonal sale',
+                    },
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1,
+                            },
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: 'USD',
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder");
+                window.dataLayer.length.should.eql(0);
                 done();
             });
         });
@@ -487,6 +534,10 @@ describe('Adwords forwarder', function () {
                 }, reportService.cb, 1, true);
             });
 
+            beforeEach(function() {
+                window.dataLayer = [];
+            });
+
             it('should have conversion labels for page event', function (done) {
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
@@ -509,7 +560,7 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer[1].should.match(result);
+                window.dataLayer[0].should.match(result);
 
                 done();
             });
@@ -732,6 +783,42 @@ describe('Adwords forwarder', function () {
                 failMessage.should.not.be.null();
                 failMessage.should.be.containEql("Can't send to forwarder")
                 window.dataLayer.length.should.eql(0)
+                done();
+            });
+
+            it('should not forward unmapped ecommerce events', function(done) {
+                var failMessage = mParticle.forwarder.process({
+                    EventName: 'eCommerce - AddToCart',
+                    EventDataType: MessageType.Commerce,
+                    EventAttributes: {
+                        sale: 'seasonal sale',
+                    },
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1,
+                            },
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: 'USD',
+                });
+
+                failMessage.should.not.be.null();
+                failMessage.should.be.containEql("Can't send to forwarder");
+                window.dataLayer.length.should.eql(0);
                 done();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -611,7 +611,7 @@ describe('Adwords forwarder', function () {
                     'conversion',
                     {
                         'send_to': 'AW-123123123/commerceLabel123',
-                        order_id: 123,
+                        transaction_id: 123,
                         value: 450,
                         currency: 'USD',
                     }
@@ -659,16 +659,18 @@ describe('Adwords forwarder', function () {
                     EventCategory: EventType.Navigation,
                     EventAttributes: {
                         attributekey: 'attributevalue'
-                    }
+                    },
+                    SourceMessageId: 'foo-bar'
                 });
 
                 var result = [
                     'event',
                     'conversion',
                     {
-                        'send_to': 'AW-123123123/pageEventLabel123',
-                        mycustomprop: 'attributevalue'
-                    }
+                        send_to: 'AW-123123123/pageEventLabel123',
+                        mycustomprop: 'attributevalue',
+                        transaction_id: 'foo-bar',
+                    },
                 ];
 
                 successMessage.should.not.be.null();

--- a/test/tests.js
+++ b/test/tests.js
@@ -898,12 +898,82 @@ describe('Adwords forwarder', function () {
                     true
                 );
             });
+            beforeEach(function() {
+                window.enhanced_conversion_data = {};
+            })
 
-            it('should set enhanced conversions', function(done) {
+            it('should set enhanced conversion data on custom events', function(done) {
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageEvent,
                     EventCategory: EventType.Navigation,
+                    CustomFlags: {
+                        'GoogleAds.ECData': {
+                            email: 'test@gmail.com',
+                            phone_number: '1-911-867-5309',
+                            first_name: 'John',
+                            last_name: 'Doe',
+                            home_address: {
+                                street: '123 Main St',
+                                city: 'San Francisco',
+                                region: 'CA',
+                                postal_code: '12345',
+                                country: 'US',
+                            },
+                        },
+                    },
+                });
+
+                window.enhanced_conversion_data.email.should.equal(
+                    'test@gmail.com'
+                );
+                window.enhanced_conversion_data.phone_number.should.equal(
+                    '1-911-867-5309'
+                );
+                window.enhanced_conversion_data.first_name.should.equal('John');
+                window.enhanced_conversion_data.last_name.should.equal('Doe');
+                window.enhanced_conversion_data.home_address.street.should.equal(
+                    '123 Main St'
+                );
+                window.enhanced_conversion_data.home_address.city.should.equal(
+                    'San Francisco'
+                );
+                window.enhanced_conversion_data.home_address.region.should.equal(
+                    'CA'
+                );
+                window.enhanced_conversion_data.home_address.postal_code.should.equal(
+                    '12345'
+                );
+                window.enhanced_conversion_data.home_address.country.should.equal('US');
+
+                done();
+            });
+
+            it('should set enhanced conversion data on commerce events', function(done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'eCommerce - Purchase',
+                    EventDataType: MessageType.Commerce,
+                    ProductAction: {
+                        ProductActionType: ProductActionType.Purchase,
+                        ProductList: [
+                            {
+                                Sku: '12345',
+                                Name: 'iPhone 6',
+                                Category: 'Phones',
+                                Brand: 'iPhone',
+                                Variant: '6',
+                                Price: 400,
+                                CouponCode: null,
+                                Quantity: 1,
+                            },
+                        ],
+                        TransactionId: 123,
+                        Affiliation: 'my-affiliation',
+                        TotalAmount: 450,
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                    },
+                    CurrencyCode: 'USD',
                     CustomFlags: {
                         'GoogleAds.ECData': {
                             email: 'test@gmail.com',

--- a/test/tests.js
+++ b/test/tests.js
@@ -116,6 +116,9 @@ describe('Adwords forwarder', function () {
     }
 
     describe('Legacy Conversion Async', function () {
+        beforeEach(function() {
+            window.dataLayer = undefined;
+        });
         describe("Page View Conversion Label", function () {
             before(function () {
 
@@ -150,7 +153,6 @@ describe('Adwords forwarder', function () {
 
         describe("Page Event Conversion Label", function () {
             before(function () {
-
                 var map = [{ "maptype": "EventClass.Id", "value": "pageEventLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.PageEvent + "" +  EventType.Navigation + 'Homepage') }]
 
                 mParticle.forwarder.init({
@@ -468,7 +470,7 @@ describe('Adwords forwarder', function () {
                     }
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -479,7 +481,7 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.match([expectedDataLayer]);
+                window.dataLayer[1].should.match(result);
 
                 done();
             });
@@ -512,7 +514,7 @@ describe('Adwords forwarder', function () {
                     }
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -523,7 +525,7 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.match([expectedDataLayer]);
+                window.dataLayer[1].should.match(result);
 
                 done();
             });
@@ -570,7 +572,7 @@ describe('Adwords forwarder', function () {
                     CurrencyCode: "USD"
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -584,7 +586,7 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.match([expectedDataLayer]);
+                window.dataLayer[1].should.match(result);
 
                 done();
             });
@@ -612,9 +614,11 @@ describe('Adwords forwarder', function () {
                     conversionId: '123123123'
                 }, reportService.cb, 1, true);
             });
+            this.afterEach(function() {
+                window.dataLayer = [];
+            });
 
             it('should have custom params for page event', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageEvent,
@@ -624,7 +628,7 @@ describe('Adwords forwarder', function () {
                     }
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -635,14 +639,12 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.match([expectedDataLayer]);
+                window.dataLayer[1].should.match(result);
 
                 done();
             });
 
             it('should have custom params for page view', function (done) {
-
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: 'Homepage',
                     EventDataType: MessageType.PageView,
@@ -651,7 +653,7 @@ describe('Adwords forwarder', function () {
                     }
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -662,13 +664,13 @@ describe('Adwords forwarder', function () {
 
                 successMessage.should.not.be.null();
                 successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.matchAny(expectedDataLayer);
+
+                window.dataLayer[0].should.match(result);
 
                 done();
             });
 
             it('should have custom params for commerce event', function (done) {
-
                 var successMessage = mParticle.forwarder.process({
                     EventName: "eCommerce - Purchase",
                     EventDataType: MessageType.Commerce,
@@ -698,7 +700,7 @@ describe('Adwords forwarder', function () {
                     CurrencyCode: "USD"
                 });
 
-                var expectedDataLayer = [
+                var result = [
                     'event',
                     'conversion',
                     {
@@ -712,8 +714,9 @@ describe('Adwords forwarder', function () {
                 ];
 
                 successMessage.should.not.be.null();
-                successMessage.should.be.equal("Successfully sent to GoogleAdWords")
-                window.dataLayer.should.matchAny(expectedDataLayer);
+                successMessage.should.be.equal("Successfully sent to GoogleAdWords");
+
+                window.dataLayer[0].should.match(result);
 
                 done();
             });
@@ -721,8 +724,6 @@ describe('Adwords forwarder', function () {
 
         describe("Unmapped conversion labels", function () {
             before(function () {
-                window.dataLayer = undefined;
-
                 var map = [{ "maptype": "EventClassDetails.Id", "value": "commerceLabel123", "map": "0", "jsmap": mParticle.generateHash(MessageType.Commerce + "" + "eCommerce - Purchase") }]
 
                 mParticle.forwarder.init({
@@ -731,6 +732,10 @@ describe('Adwords forwarder', function () {
                     conversionId: '123123123'
                 }, reportService.cb, 1, true);
             });
+
+            beforeEach(function() {
+                window.dataLayer = [];
+            })
 
             it('should not forward unmapped events', function (done) {
                 var failMessage = mParticle.forwarder.process({
@@ -751,8 +756,6 @@ describe('Adwords forwarder', function () {
 
         describe("Bad Label Json", function () {
             before(function () {
-                window.dataLayer = undefined;
-
                 // The ids are calculated based on the events used in the tests below so they must match exactly.
                 mParticle.forwarder.init({
                     enableGtag: 'True',
@@ -761,6 +764,9 @@ describe('Adwords forwarder', function () {
                 }, reportService.cb, 1, true);
             });
 
+            beforeEach(function() {
+                window.dataLayer = [];
+            });
 
             it('should not forward with bad labels json', function (done) {
 
@@ -779,17 +785,18 @@ describe('Adwords forwarder', function () {
             });
         });
 
-
         describe("Bad Custom Parameters Json", function () {
             before(function () {
-                window.dataLayer = undefined;
-
                 // The ids are calculated based on the events used in the tests below so they must match exactly.
                 mParticle.forwarder.init({
                     enableGtag: 'True',
                     customParameters: 'sdpfuhasdflasdjfnsdjfsdjfn really baddd json',
                     conversionId: '123123123'
                 }, reportService.cb, 1, true);
+            });
+
+            beforeEach(function() {
+                window.dataLayer = [];
             });
 
 
@@ -809,5 +816,66 @@ describe('Adwords forwarder', function () {
             });
         });
 
+        describe('Enhanced Conversions', function(done) {
+            before(function() {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableEnhancedConversions: 'True',
+                        enableGtag: 'True',
+                    },
+                    reportService.cb,
+                    true,
+                    true
+                );
+            });
+
+            it('should set enhanced conversions', function(done) {
+                var successMessage = mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    CustomFlags: {
+                        'GoogleAds.ECData': {
+                            email: 'test@gmail.com',
+                            phone_number: '1-911-867-5309',
+                            first_name: 'John',
+                            last_name: 'Doe',
+                            home_address: {
+                                street: '123 Main St',
+                                city: 'San Francisco',
+                                region: 'CA',
+                                postal_code: '12345',
+                                country: 'US',
+                            },
+                        },
+                    },
+                });
+
+                window.enhanced_conversion_data.email.should.equal(
+                    'test@gmail.com'
+                );
+                window.enhanced_conversion_data.phone_number.should.equal(
+                    '1-911-867-5309'
+                );
+                window.enhanced_conversion_data.first_name.should.equal('John');
+                window.enhanced_conversion_data.last_name.should.equal('Doe');
+                window.enhanced_conversion_data.home_address.street.should.equal(
+                    '123 Main St'
+                );
+                window.enhanced_conversion_data.home_address.city.should.equal(
+                    'San Francisco'
+                );
+                window.enhanced_conversion_data.home_address.region.should.equal(
+                    'CA'
+                );
+                window.enhanced_conversion_data.home_address.postal_code.should.equal(
+                    '12345'
+                );
+                window.enhanced_conversion_data.home_address.country.should.equal('US');
+
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR adds a custom flag to allow our customers to implement enhanced conversions.

They have to set up a custom flag as 
```
{
  "GoogleAds.ECData": data
}
```
where `data` follows the table found under `Identify and define your enhanced conversions variables`  over in [Google's Docs](https://support.google.com/google-ads/answer/9888145#zippy=%2Cconfigure-your-conversion-page-global-site-tag%2Cidentify-and-define-your-enhanced-conversions-variables). For reference, I am pasting a table below.

![image](https://user-images.githubusercontent.com/5377436/139732594-699a9e0a-2a76-4c69-9dd5-01e7a7f42cae.png)

The gist is that there is a global variable, `window.enhanced_conversion_data`, that contains information per the above table.  When this is filled out, gtag will hash it and send it to Google along with the conversion payload.  

As an example, firing:
```
mParticle.logEvent(
   'Test', 
   mParticle.EventType.Navigation, 
   {attr1: 'val1'}, 
   {"GoogleAds.ECData": {email:'abc@gmail.com'}}
);
```
will associate a hashed email of `abc@gmail.com` with the `Test` event assuming `Test` is a properly mapped event.