### PR TITLE
feat: Add support for Consent State Updates

### DIFF
--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -286,10 +286,13 @@
             var consentSettings = {};
 
             var googleToMpConsentSettingsMapping = {
-                ad_storage: 'adStorageConsentSDK',
-                ad_user_data: 'adUserDataConsentSDK',
-                ad_personalization: 'adPersonalizationConsentSDK',
-                analytics_storage: 'analyticsStorageConsentSDK'
+                // Inherited from S2S Integration Settings
+                ad_user_data: 'adUserDataConsentWeb',
+                ad_personalization: 'adPersonalizationConsent',
+
+                // Unique to Web Kits
+                ad_storage: 'adStorageConsentWeb',
+                analytics_storage: 'analyticsStorageConsentWeb'
             }
 
             Object.keys(googleToMpConsentSettingsMapping).forEach(function (googleConsentKey) {
@@ -535,9 +538,9 @@
 
                 // https://go.mparticle.com/work/SQDSDKS-6165
                 if (window.gtag && forwarderSettings.enableGtag === 'True') {
-                    if (forwarderSettings.consentMappingSDK) {
+                    if (forwarderSettings.consentMappingWeb) {
                         consentMappings = parseSettingsString(
-                            forwarderSettings.consentMappingSDK
+                            forwarderSettings.consentMappingWeb
                         );
                     }
     

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -28,6 +28,7 @@
         },
         ENHANCED_CONVERSION_DATA = "GoogleAds.ECData";
 
+    // Declares valid Google consent values
     var googleConsentValues = {
         // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
         // However, this is not used by Google's Web SDK. We are referencing it here as a comment 
@@ -38,6 +39,7 @@
         Granted: 'granted',
     };
 
+    // Declares list of valid Google Consent Properties
     var googleConsentProperties = [
         'ad_storage',
         'ad_user_data',
@@ -45,6 +47,13 @@
         'analytics_storage',
     ];
 
+    // Maps Consent Settings to Forwarder Settings
+    var forwarderSettingsMapping = {
+        ad_storage: 'adStorageConsentWeb',
+        ad_user_data: 'adUserDataConsentWeb',
+        ad_personalization: 'adPersonalizationConsentWeb',
+        analytics_storage: 'analyticsStorageConsentWeb'
+    }
 
     var constructor = function () {
         var self = this,
@@ -279,42 +288,14 @@
 
         function getConsentSettings() {
             var consentSettings = {};
-    
-            if (
-                forwarderSettings.adStorageConsentWeb &&
-                googleConsentValues[forwarderSettings.adStorageConsentWeb]
-            ) {
-                consentSettings['ad_storage'] =
-                    googleConsentValues[forwarderSettings.adStorageConsentWeb];
-            }
-    
-            if (
-                forwarderSettings.adUserDataConsentWeb &&
-                googleConsentValues[forwarderSettings.adUserDataConsentWeb]
-            ) {
-                consentSettings['ad_user_data'] =
-                    googleConsentValues[forwarderSettings.adUserDataConsentWeb];
-            }
-    
-            if (
-                forwarderSettings.adPersonalizationConsentWeb &&
-                googleConsentValues[forwarderSettings.adPersonalizationConsentWeb]
-            ) {
-                consentSettings['ad_personalization'] =
-                    googleConsentValues[
-                        forwarderSettings.adPersonalizationConsentWeb
-                    ];
-            }
-    
-            if (
-                forwarderSettings.analyticsStorageConsentWeb &&
-                googleConsentValues[forwarderSettings.analyticsStorageConsentWeb]
-            ) {
-                consentSettings['analytics_storage'] =
-                    googleConsentValues[
-                        forwarderSettings.analyticsStorageConsentWeb
-                    ];
-            }
+
+            Object.keys(forwarderSettingsMapping).forEach(function (settingsKey) {
+                var forwarderSettingsKey = forwarderSettingsMapping[settingsKey];
+                var googleConsentValuesKey = forwarderSettings[forwarderSettingsKey]
+                if (forwarderSettings[forwarderSettingsKey] && googleConsentValues[googleConsentValuesKey]){
+                    consentSettings[settingsKey] = googleConsentValues[googleConsentValuesKey];
+                }
+            });
     
             return consentSettings;
         }

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -33,6 +33,10 @@
         // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
         // However, this is not used by Google's Web SDK. We are referencing it here as a comment 
         // as a record of this distinction and for posterity.
+        //
+        // Docs:
+        // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
+        // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
         // 
         // Unspecified: 'unspecified',
         Denied: 'denied',

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -77,17 +77,17 @@
                         var eventConsentState = getEventConsentState(event);
 
                         if (eventConsentState) {
-                            var updateConsentPayload = generateConsentStatePayloadFromMappings(
+                            var updatedConsentPayload = generateConsentStatePayloadFromMappings(
                                 eventConsentState,
                                 consentMappings,
                                 consentPayloadDefaults,
                             );
     
                             var eventPayloadHashAsString =
-                                stringifyPayload(updateConsentPayload);
+                                stringifyPayload(updatedConsentPayload);
     
                             if (eventPayloadHashAsString !== consentPayloadAsString) {
-                                sendGtagConsentUpdate(updateConsentPayload);
+                                sendGtagConsentUpdate(updatedConsentPayload);
                                 consentPayloadAsString = eventPayloadHashAsString;
                             }
                         }

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -92,12 +92,12 @@
                                 consentPayloadDefaults,
                             );
     
-                            var eventPayloadHashAsString =
+                            var eventPayloadAsString =
                                 JSON.stringify(updatedConsentPayload);
     
-                            if (eventPayloadHashAsString !== consentPayloadAsString) {
+                            if (eventPayloadAsString !== consentPayloadAsString) {
                                 sendGtagConsentUpdate(updatedConsentPayload);
-                                consentPayloadAsString = eventPayloadHashAsString;
+                                consentPayloadAsString = eventPayloadAsString;
                             }
                         }
 
@@ -507,14 +507,6 @@
             reportingService = service;
 
             try {
-                if (forwarderSettings.consentMappingWeb) {
-                    consentMappings = parseSettingsString(
-                        forwarderSettings.consentMappingWeb
-                    );
-                }
-
-                consentPayloadDefaults = getConsentSettings();
-
                 if (!forwarderSettings.conversionId) {
                     return 'Can\'t initialize forwarder: ' + name + ', conversionId is not defined';
                 }
@@ -537,6 +529,14 @@
                 }
 
                 if (window.gtag && forwarderSettings.enableGtag === 'True') {
+                    if (forwarderSettings.consentMappingWeb) {
+                        consentMappings = parseSettingsString(
+                            forwarderSettings.consentMappingWeb
+                        );
+                    }
+    
+                    consentPayloadDefaults = getConsentSettings();
+
                     var initialConsentState = getUserConsentState();
 
                     if (initialConsentState) {

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -52,14 +52,6 @@
         'analytics_storage',
     ];
 
-    // Maps Consent Settings to Forwarder Settings
-    var forwarderSettingsMapping = {
-        ad_storage: 'adStorageConsentWeb',
-        ad_user_data: 'adUserDataConsentWeb',
-        ad_personalization: 'adPersonalizationConsentWeb',
-        analytics_storage: 'analyticsStorageConsentWeb'
-    }
-
     var constructor = function () {
         var self = this,
             isInitialized = false,
@@ -293,11 +285,19 @@
         function getConsentSettings() {
             var consentSettings = {};
 
-            Object.keys(forwarderSettingsMapping).forEach(function (settingsKey) {
-                var forwarderSettingsKey = forwarderSettingsMapping[settingsKey];
-                var googleConsentValuesKey = forwarderSettings[forwarderSettingsKey]
-                if (forwarderSettings[forwarderSettingsKey] && googleConsentValues[googleConsentValuesKey]){
-                    consentSettings[settingsKey] = googleConsentValues[googleConsentValuesKey];
+            var googleToMpConsentSettingsMapping = {
+                ad_storage: 'adStorageConsentWeb',
+                ad_user_data: 'adUserDataConsentWeb',
+                ad_personalization: 'adPersonalizationConsentWeb',
+                analytics_storage: 'analyticsStorageConsentWeb'
+            }
+
+            Object.keys(googleToMpConsentSettingsMapping).forEach(function (googleConsentKey) {
+                var mpConsentSettingKey = googleToMpConsentSettingsMapping[googleConsentKey];
+                var googleConsentValuesKey = forwarderSettings[mpConsentSettingKey]
+
+                if (googleConsentValuesKey && mpConsentSettingKey){
+                    consentSettings[googleConsentKey] = googleConsentValues[googleConsentValuesKey];
                 }
             });
     

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -84,7 +84,7 @@
                             );
     
                             var eventPayloadHashAsString =
-                                stringifyPayload(updatedConsentPayload);
+                                JSON.stringify(updatedConsentPayload);
     
                             if (eventPayloadHashAsString !== consentPayloadAsString) {
                                 sendGtagConsentUpdate(updatedConsentPayload);
@@ -401,17 +401,19 @@
         }
 
         // Creates a new Consent State Payload based on Consent State and Mapping
-        function generateConsentStatePayloadFromMappings(consentState, mappings, defaults) {
-            var payload = cloneObject(defaults);
+        function generateConsentStatePayloadFromMappings(consentState, mappings) {
+            var payload = cloneObject(consentPayloadDefaults);
     
             for (var i = 0; i <= mappings.length - 1; i++) {
                 var mappingEntry = mappings[i];
+                var mpMappedConsentName = mappingEntry.map;
+                var googleMappedConsentName = mappingEntry.value;
+
                 if (
-                    consentState[mappingEntry.map] &&
-                    mappingEntry.maptype === 'ConsentPurposes' &&
-                    googleConsentProperties.includes(mappingEntry.value)
+                    consentState[mpMappedConsentName] &&
+                    googleConsentProperties.includes(googleMappedConsentName)
                 ) {
-                    payload[mappingEntry.value] = consentState[mappingEntry.map]
+                    payload[googleMappedConsentName] = consentState[mpMappedConsentName]
                         .Consented
                         ? googleConsentValues.Granted
                         : googleConsentValues.Denied;
@@ -419,10 +421,6 @@
             }
     
             return payload;
-        }
-
-        function stringifyPayload(payload) {
-            return Object.entries(payload).join(',');
         }
 
         // Looks up an Event's conversionLabel from customAttributeMappings based on computed jsHash value
@@ -557,7 +555,7 @@
                     return 'Can\'t initialize forwarder: ' + name + ', conversionId is not defined';
                 }
 
-                if (window.gtag && forwarderSettings.enableGtag == 'True') {
+                if (window.gtag && forwarderSettings.enableGtag === 'True') {
                     var initialConsentState = getUserConsentState();
 
                     if (initialConsentState) {
@@ -567,7 +565,7 @@
                                 consentMappings,
                                 consentPayloadDefaults,
                             );
-                        consentPayloadAsString = stringifyPayload(defaultConsentPayload);
+                        consentPayloadAsString = JSON.stringify(defaultConsentPayload);
 
                         sendGtagConsentDefaults(defaultConsentPayload);
                     }

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -80,7 +80,7 @@
 
                 try {
                     if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                        var eventConsentState = getEventConsentState(event);
+                        var eventConsentState = getEventConsentState(event.ConsentState);
 
                         if (eventConsentState) {
                             var updatedConsentPayload = generateConsentStatePayloadFromMappings(
@@ -231,15 +231,11 @@
             return userConsentState;
         }
 
-        function getEventConsentState(event) {
-            var eventConsentState = null;
-
-            if (event && event.ConsentState) {
-                eventConsentState = event.ConsentState.getGDPRConsentState();
-            }
-
-            return eventConsentState;
-        }
+        function getEventConsentState(eventConsentState) {
+            return eventConsentState && eventConsentState.getGDPRConsentState
+                ? eventConsentState.getGDPRConsentState()
+                : null;
+        };
 
         // ** Adwords Events
         function getBaseAdWordEvent() {

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -536,10 +536,9 @@
                     }
     
                     consentPayloadDefaults = getConsentSettings();
-
                     var initialConsentState = getUserConsentState();
 
-                    if (initialConsentState) {
+                    if (consentPayloadDefaults && initialConsentState) {
                         var defaultConsentPayload =
                             generateConsentStatePayloadFromMappings(
                                 initialConsentState,

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -205,6 +205,12 @@
             let userConsentState = null;
 
             if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
+                const currentUser = mParticle.Identity.getCurrentUser();
+
+                if (!currentUser) {
+                    return null;
+                }
+
                 const consentState =
                     mParticle.Identity.getCurrentUser().getConsentState();
 
@@ -212,7 +218,7 @@
                     userConsentState = consentState.getGDPRConsentState();
                 }
             }
-    
+
             return userConsentState;
         }
 

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -532,6 +532,7 @@
                     return 'Can\'t initialize forwarder: ' + name + ', conversionId is not defined';
                 }
 
+                // https://go.mparticle.com/work/SQDSDKS-6165
                 if (window.gtag && forwarderSettings.enableGtag === 'True') {
                     if (forwarderSettings.consentMappingWeb) {
                         consentMappings = parseSettingsString(

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -404,15 +404,15 @@
         function generateConsentStatePayloadFromMappings(consentState, mappings, defaults) {
             var payload = cloneObject(defaults);
     
-            for (var mappingEntry of mappings) {
+            for (var i = 0; i <= mappings.length - 1; i++) {
+                var mappingEntry = mappings[i];
                 if (
                     consentState[mappingEntry.map] &&
                     mappingEntry.maptype === 'ConsentPurposes' &&
                     googleConsentProperties.includes(mappingEntry.value)
                 ) {
-                    payload[mappingEntry.value] = consentState[
-                        mappingEntry.map
-                    ].Consented
+                    payload[mappingEntry.value] = consentState[mappingEntry.map]
+                        .Consented
                         ? googleConsentValues.Granted
                         : googleConsentValues.Denied;
                 }

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -213,15 +213,15 @@
         function getUserConsentState() {
             var userConsentState = null;
 
-            if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
-                var currentUser = mParticle.Identity.getCurrentUser();
+            if (window.mParticle && window.mParticle.Identity && window.mParticle.Identity.getCurrentUser) {
+                var currentUser = window.mParticle.Identity.getCurrentUser();
 
                 if (!currentUser) {
                     return null;
                 }
 
                 var consentState =
-                    mParticle.Identity.getCurrentUser().getConsentState();
+                    window.mParticle.Identity.getCurrentUser().getConsentState();
 
                 if (consentState && consentState.getGDPRConsentState) {
                     userConsentState = consentState.getGDPRConsentState();

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -74,7 +74,7 @@
 
                 try {
                     if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                        const eventConsentState = getEventConsentState(event);
+                        var eventConsentState = getEventConsentState(event);
 
                         if (eventConsentState) {
                             var updateConsentPayload = generateConsentStatePayloadFromMappings(
@@ -206,16 +206,16 @@
         }
 
         function getUserConsentState() {
-            let userConsentState = null;
+            var userConsentState = null;
 
             if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
-                const currentUser = mParticle.Identity.getCurrentUser();
+                var currentUser = mParticle.Identity.getCurrentUser();
 
                 if (!currentUser) {
                     return null;
                 }
 
-                const consentState =
+                var consentState =
                     mParticle.Identity.getCurrentUser().getConsentState();
 
                 if (consentState && consentState.getGDPRConsentState) {
@@ -227,7 +227,7 @@
         }
 
         function getEventConsentState(event) {
-            let eventConsentState = null;
+            var eventConsentState = null;
 
             if (event && event.ConsentState) {
                 eventConsentState = event.ConsentState.getGDPRConsentState();
@@ -278,7 +278,7 @@
         }
 
         function getConsentSettings() {
-            const consentSettings = {};
+            var consentSettings = {};
     
             if (
                 forwarderSettings.adStorageConsentWeb &&
@@ -402,7 +402,7 @@
 
         // Creates a new Consent State Payload based on Consent State and Mapping
         function generateConsentStatePayloadFromMappings(consentState, mappings, defaults) {
-            const payload = cloneObject(defaults);
+            var payload = cloneObject(defaults);
     
             for (var mappingEntry of mappings) {
                 if (
@@ -558,7 +558,7 @@
                 }
 
                 if (window.gtag && forwarderSettings.enableGtag == 'True') {
-                    const initialConsentState = getUserConsentState();
+                    var initialConsentState = getUserConsentState();
 
                     if (initialConsentState) {
                         var defaultConsentPayload =

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -505,6 +505,7 @@
             })();
         }
 
+        // https://go.mparticle.com/work/SQDSDKS-6166
         function initForwarder(settings, service, testMode) {
             window.enhanced_conversion_data = {};
             forwarderSettings = settings;

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -33,6 +33,7 @@
         // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
         // However, this is not used by Google's Web SDK. We are referencing it here as a comment 
         // as a record of this distinction and for posterity.
+        // If Google ever adds this for web, the line can just be uncommented to support this.
         //
         // Docs:
         // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
@@ -93,15 +94,14 @@
                             var updatedConsentPayload = generateConsentStatePayloadFromMappings(
                                 eventConsentState,
                                 consentMappings,
-                                consentPayloadDefaults,
                             );
     
-                            var eventPayloadAsString =
+                            var eventConsentAsString =
                                 JSON.stringify(updatedConsentPayload);
     
-                            if (eventPayloadAsString !== consentPayloadAsString) {
+                            if (eventConsentAsString !== consentPayloadAsString) {
                                 sendGtagConsentUpdate(updatedConsentPayload);
-                                consentPayloadAsString = eventPayloadAsString;
+                                consentPayloadAsString = eventConsentAsString;
                             }
                         }
 
@@ -396,7 +396,7 @@
 
                 if (
                     consentState[mpMappedConsentName] &&
-                    googleConsentProperties.includes(googleMappedConsentName)
+                    googleConsentProperties.indexOf(googleMappedConsentName) !== -1
                 ) {
                     payload[googleMappedConsentName] = consentState[mpMappedConsentName]
                         .Consented
@@ -549,7 +549,6 @@
                             generateConsentStatePayloadFromMappings(
                                 initialConsentState,
                                 consentMappings,
-                                consentPayloadDefaults,
                             );
                         consentPayloadAsString = JSON.stringify(defaultConsentPayload);
 

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -288,12 +288,12 @@
 
             var googleToMpConsentSettingsMapping = {
                 // Inherited from S2S Integration Settings
-                ad_user_data: 'adUserDataConsent',
-                ad_personalization: 'adPersonalizationConsent',
+                ad_user_data: 'defaultAdUserDataConsent',
+                ad_personalization: 'defaultAdPersonalizationConsent',
 
                 // Unique to Web Kits
-                ad_storage: 'adStorageConsentWeb',
-                analytics_storage: 'analyticsStorageConsentWeb'
+                ad_storage: 'defaultAdStorageConsentWeb',
+                analytics_storage: 'defaultAnalyticsStorageConsentWeb'
             }
 
             Object.keys(googleToMpConsentSettingsMapping).forEach(function (googleConsentKey) {

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -29,7 +29,11 @@
         ENHANCED_CONVERSION_DATA = "GoogleAds.ECData";
 
     var googleConsentValues = {
-        // Unspecified: 'unspecified', // Used by S2S but we will filter out unspecified values
+        // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
+        // However, this is not used by Google's Web SDK. We are referencing it here as a comment 
+        // as a record of this distinction and for posterity.
+        // 
+        // Unspecified: 'unspecified',
         Denied: 'denied',
         Granted: 'granted',
     };

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -286,10 +286,10 @@
             var consentSettings = {};
 
             var googleToMpConsentSettingsMapping = {
-                ad_storage: 'adStorageConsentWeb',
-                ad_user_data: 'adUserDataConsentWeb',
-                ad_personalization: 'adPersonalizationConsentWeb',
-                analytics_storage: 'analyticsStorageConsentWeb'
+                ad_storage: 'adStorageConsentSDK',
+                ad_user_data: 'adUserDataConsentSDK',
+                ad_personalization: 'adPersonalizationConsentSDK',
+                analytics_storage: 'analyticsStorageConsentSDK'
             }
 
             Object.keys(googleToMpConsentSettingsMapping).forEach(function (googleConsentKey) {
@@ -535,9 +535,9 @@
 
                 // https://go.mparticle.com/work/SQDSDKS-6165
                 if (window.gtag && forwarderSettings.enableGtag === 'True') {
-                    if (forwarderSettings.consentMappingWeb) {
+                    if (forwarderSettings.consentMappingSDK) {
                         consentMappings = parseSettingsString(
-                            forwarderSettings.consentMappingWeb
+                            forwarderSettings.consentMappingSDK
                         );
                     }
     

--- a/src/GoogleAdWordsEventForwarder.js
+++ b/src/GoogleAdWordsEventForwarder.js
@@ -86,7 +86,7 @@
                         if (consentPayloadAsString && forwarderSettings.consentMappingWeb) {
                             var eventConsentState = getEventConsentState(event.ConsentState);
 
-                            if (eventConsentState) {
+                            if (!isEmpty(eventConsentState)) {
                                 var updatedConsentPayload = generateConsentStatePayloadFromMappings(
                                     eventConsentState,
                                     consentMappings,
@@ -216,13 +216,13 @@
         }
 
         function getUserConsentState() {
-            var userConsentState = null;
+            var userConsentState = {};
 
             if (window.mParticle && window.mParticle.Identity && window.mParticle.Identity.getCurrentUser) {
                 var currentUser = window.mParticle.Identity.getCurrentUser();
 
                 if (!currentUser) {
-                    return null;
+                    return {};
                 }
 
                 var consentState =
@@ -239,7 +239,7 @@
         function getEventConsentState(eventConsentState) {
             return eventConsentState && eventConsentState.getGDPRConsentState
                 ? eventConsentState.getGDPRConsentState()
-                : null;
+                : {};
         };
 
         // ** Adwords Events

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1196,11 +1196,14 @@ describe('Adwords forwarder', function () {
             });
 
             it('should construct a Default Consent State Payload from Mappings', function (done) {
+                // We are intentionally using a string here instead of `JSON.stringify(consentMap)`
+                // so that we can also test how consentMapingWeb is parsed when returned as a string
+                // from the mParticle config
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
+                        consentMappingWeb: '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,
                     true

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1173,7 +1173,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMapping:
+                        consentMappingWeb:
                             '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,
@@ -1196,12 +1196,80 @@ describe('Adwords forwarder', function () {
                 done();
             });
 
+            it('should construct a Default Consent State with Consent Settings Defaults', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMappingWeb:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentWeb: 'Granted',
+                        analyticsStorageConsentWeb: 'Granted',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayer = [
+                    'consent',
+                    'default',
+                    {
+                        ad_personalization: 'denied', // From User Consent State
+                        ad_user_data: 'denied', // From User Consent State
+                        ad_storage: 'granted', // From Consent Settings
+                        analytics_storage: 'granted', // From Consent Settings
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(expectedDataLayer[2]);
+
+                done();
+            });
+
+            it('should ignore Unspecified Consent Settings if NOT explicitely defined in Consent State', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMappingWeb:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                        adUserDataConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                        adPersonalizationConsentWeb: 'Unspecified',
+                        analyticsStorageConsentWeb: 'Unspecified',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayer = [
+                    'consent',
+                    'default',
+                    {
+                        ad_personalization: 'denied', // From User Consent State
+                        ad_user_data: 'denied', // From User Consent State
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(expectedDataLayer[2]);
+
+                done();
+            });
+
             it('should construct a Consent State Update Payload when consent changes', function (done) {
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMapping:
+                        consentMappingWeb:
                             '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,
@@ -1327,7 +1395,7 @@ describe('Adwords forwarder', function () {
                                 data_sale_opt_out: {
                                     Consented: false,
                                     Timestamp: Date.now(),
-                                    Document: 'some_consent',
+                                    Document: 'data_sale_opt_out',
                                 },
                             };
                         },
@@ -1354,12 +1422,178 @@ describe('Adwords forwarder', function () {
                 done();
             });
 
+            it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMappingWeb:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentWeb: 'Granted',
+                        analyticsStorageConsentWeb: 'Granted',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayerBefore = [
+                    'consent',
+                    'update',
+                    {
+                        ad_personalization: 'denied', // From User Consent State
+                        ad_user_data: 'denied', // From User Consent State
+                        ad_storage: 'granted', // From Consent Settings
+                        analytics_storage: 'granted', // From Consent Settings
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(
+                    expectedDataLayerBefore[2]
+                );
+
+                mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock',
+                    },
+                    ConsentState: {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                                ignored_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'ignored_consent',
+                                },
+                                test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'test_consent',
+                                },
+                            };
+                        },
+
+                        getCCPAConsentState: function () {
+                            return {
+                                data_sale_opt_out: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'data_sale_opt_out',
+                                },
+                            };
+                        },
+                    },
+                });
+
+                var expectedDataLayerAfter = [
+                    'consent',
+                    'update',
+                    {
+                        ad_personalization: 'granted', // From Event Consent State Change
+                        ad_user_data: 'granted', // From Event Consent State Change
+                        ad_storage: 'granted', // From Consent Settings
+                        analytics_storage: 'granted', // From Consent Settings
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(2);
+                window.dataLayer[1][0].should.equal('consent');
+                window.dataLayer[1][1].should.equal('update');
+                window.dataLayer[1][2].should.deepEqual(
+                    expectedDataLayerAfter[2]
+                );
+
+                mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock',
+                    },
+                    ConsentState: {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                                ignored_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'ignored_consent',
+                                },
+                                test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'test_consent',
+                                },
+                                other_test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'other_test_consent',
+                                },
+                                storage_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'storage_consent',
+                                },
+                            };
+                        },
+
+                        getCCPAConsentState: function () {
+                            return {
+                                data_sale_opt_out: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'data_sale_opt_out',
+                                },
+                            };
+                        },
+                    },
+                });
+
+                var expectedDataLayerFinal = [
+                    'consent',
+                    'update',
+                    {
+                        ad_personalization: 'granted', // From Previous Event State Change
+                        ad_storage: 'granted', // From Previous Event State Change
+                        ad_user_data: 'granted', // From Consent Settings
+                        analytics_storage: 'denied', // From FinalEvent Consent State Change
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(3);
+                window.dataLayer[2][0].should.equal('consent');
+                window.dataLayer[2][1].should.equal('update');
+                window.dataLayer[2][2].should.deepEqual(
+                    expectedDataLayerFinal[2]
+                );
+                done();
+            });
+
             it('should NOT construct a Consent State Update Payload if consent DOES NOT changes', function (done) {
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMapping:
+                        consentMappingWeb:
                             '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1197,7 +1197,7 @@ describe('Adwords forwarder', function () {
 
             it('should construct a Default Consent State Payload from Mappings', function (done) {
                 // We are intentionally using a string here instead of `JSON.stringify(consentMap)`
-                // so that we can also test how consentMapingWeb is parsed when returned as a string
+                // so that we can also test how consentMappingWeb is parsed when returned as a string
                 // from the mParticle config
                 mParticle.forwarder.init(
                     {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1743,8 +1743,6 @@ describe('Adwords forwarder', function () {
             });
 
             it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', function (done) {
-                debugger;
-
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1130,5 +1130,289 @@ describe('Adwords forwarder', function () {
                 done();
             });
         });
+
+        describe('Consent State', function () {
+            beforeEach(function () {
+                window.dataLayer = [];
+                window.gtag = function () {
+                    window.dataLayer.push(arguments);
+                };
+
+                mParticle.Identity = {
+                    getCurrentUser: function () {
+                        return {
+                            getConsentState: function () {
+                                return {
+                                    getGDPRConsentState: function () {
+                                        return {
+                                            some_consent: {
+                                                Consented: false,
+                                                Timestamp: 1,
+                                                Document: 'some_consent',
+                                            },
+                                            test_consent: {
+                                                Consented: false,
+                                                Timestamp: 1,
+                                                Document: 'test_consent',
+                                            },
+                                        };
+                                    },
+                                };
+                            },
+                        };
+                    },
+                };
+            });
+
+            afterEach(function () {
+                mParticle.Identity = undefined;
+            });
+
+            it('should construct a Default Consent State Payload from Mappings', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMapping:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayer = [
+                    'consent',
+                    'default',
+                    {
+                        ad_user_data: 'denied',
+                        ad_personalization: 'denied',
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(expectedDataLayer[2]);
+                done();
+            });
+
+            it('should construct a Consent State Update Payload when consent changes', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMapping:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayerBefore = [
+                    'consent',
+                    'update',
+                    {
+                        ad_user_data: 'denied',
+                        ad_personalization: 'denied',
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(
+                    expectedDataLayerBefore[2]
+                );
+
+                mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock',
+                    },
+                    ConsentState: {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                                ignored_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'ignored_consent',
+                                },
+                                test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'test_consent',
+                                },
+                            };
+                        },
+
+                        getCCPAConsentState: function () {
+                            return {
+                                data_sale_opt_out: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                            };
+                        },
+                    },
+                });
+
+                var expectedDataLayerAfter = [
+                    'consent',
+                    'update',
+                    {
+                        ad_user_data: 'granted',
+                        ad_personalization: 'granted',
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(2);
+                window.dataLayer[1][0].should.equal('consent');
+                window.dataLayer[1][1].should.equal('update');
+                window.dataLayer[1][2].should.deepEqual(
+                    expectedDataLayerAfter[2]
+                );
+
+                mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock',
+                    },
+                    ConsentState: {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                                ignored_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'ignored_consent',
+                                },
+                                test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'test_consent',
+                                },
+                                other_test_consent: {
+                                    Consented: true,
+                                    Timestamp: Date.now(),
+                                    Document: 'other_test_consent',
+                                },
+                                storage_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'storage_consent',
+                                },
+                            };
+                        },
+
+                        getCCPAConsentState: function () {
+                            return {
+                                data_sale_opt_out: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                            };
+                        },
+                    },
+                });
+
+                var expectedDataLayerFinal = [
+                    'consent',
+                    'update',
+                    {
+                        ad_personalization: 'granted',
+                        ad_storage: 'granted',
+                        ad_user_data: 'granted',
+                        analytics_storage: 'denied',
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(3);
+                window.dataLayer[2][0].should.equal('consent');
+                window.dataLayer[2][1].should.equal('update');
+                window.dataLayer[2][2].should.deepEqual(
+                    expectedDataLayerFinal[2]
+                );
+                done();
+            });
+
+            it('should NOT construct a Consent State Update Payload if consent DOES NOT changes', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        conversionId: 'AW-123123123',
+                        enableGtag: 'True',
+                        consentMapping:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                var expectedDataLayerBefore = [
+                    'consent',
+                    'update',
+                    {
+                        ad_user_data: 'denied',
+                        ad_personalization: 'denied',
+                    },
+                ];
+
+                window.dataLayer.length.should.eql(1);
+                window.dataLayer[0][0].should.equal('consent');
+                window.dataLayer[0][1].should.equal('default');
+                window.dataLayer[0][2].should.deepEqual(
+                    expectedDataLayerBefore[2]
+                );
+
+                mParticle.forwarder.process({
+                    EventName: 'Homepage',
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventAttributes: {
+                        showcase: 'something',
+                        test: 'thisoneshouldgetmapped',
+                        mp: 'rock',
+                    },
+                    ConsentState: {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'some_consent',
+                                },
+                                test_consent: {
+                                    Consented: false,
+                                    Timestamp: Date.now(),
+                                    Document: 'test_consent',
+                                },
+                            };
+                        },
+                    },
+                });
+
+                window.dataLayer.length.should.eql(1);
+
+                done();
+            });
+        });
     });
 });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1197,13 +1197,14 @@ describe('Adwords forwarder', function () {
 
             it('should construct a Default Consent State Payload from Mappings', function (done) {
                 // We are intentionally using a string here instead of `JSON.stringify(consentMap)`
-                // so that we can also test how consentMappingSDK is parsed when returned as a string
+                // so that we can also test how consentMappingWeb is parsed when returned as a string
                 // from the mParticle config
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb:
+                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,
                     true
@@ -1231,11 +1232,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: JSON.stringify(consentMap),
-                        adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentSDK: 'Granted',
-                        analyticsStorageConsentSDK: 'Granted',
+                        consentMappingWeb: JSON.stringify(consentMap),
+                        adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentWeb: 'Granted',
+                        analyticsStorageConsentWeb: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1265,11 +1266,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: JSON.stringify(consentMap),
-                        adStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
-                        adUserDataConsentSDK: 'Unspecified', // Will be overriden by User Consent State
-                        adPersonalizationConsentSDK: 'Unspecified',
-                        analyticsStorageConsentSDK: 'Unspecified',
+                        consentMappingWeb: JSON.stringify(consentMap),
+                        adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                        adUserDataConsent: 'Unspecified', // Will be overriden by User Consent State
+                        adPersonalizationConsent: 'Unspecified',
+                        analyticsStorageConsentWeb: 'Unspecified',
                     },
                     reportService.cb,
                     true
@@ -1297,7 +1298,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: JSON.stringify(consentMap),
+                        consentMappingWeb: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true
@@ -1454,11 +1455,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: JSON.stringify(consentMap),
-                        adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentSDK: 'Granted',
-                        analyticsStorageConsentSDK: 'Granted',
+                        consentMappingWeb: JSON.stringify(consentMap),
+                        adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentWeb: 'Granted',
+                        analyticsStorageConsentWeb: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1619,7 +1620,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingSDK: JSON.stringify(consentMap),
+                        consentMappingWeb: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1226,7 +1226,7 @@ describe('Adwords forwarder', function () {
                 done();
             });
 
-            it('should construct a Default Consent State with Consent Settings Defaults', function (done) {
+            it('should merge Consent Setting Defaults with User Consent State to construct a Default Consent State', function (done) {
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1197,13 +1197,13 @@ describe('Adwords forwarder', function () {
 
             it('should construct a Default Consent State Payload from Mappings', function (done) {
                 // We are intentionally using a string here instead of `JSON.stringify(consentMap)`
-                // so that we can also test how consentMappingWeb is parsed when returned as a string
+                // so that we can also test how consentMappingSDK is parsed when returned as a string
                 // from the mParticle config
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingSDK: '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     },
                     reportService.cb,
                     true
@@ -1231,11 +1231,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
-                        adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentWeb: 'Granted',
-                        analyticsStorageConsentWeb: 'Granted',
+                        consentMappingSDK: JSON.stringify(consentMap),
+                        adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentSDK: 'Granted',
+                        analyticsStorageConsentSDK: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1265,11 +1265,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
-                        adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
-                        adUserDataConsentWeb: 'Unspecified', // Will be overriden by User Consent State
-                        adPersonalizationConsentWeb: 'Unspecified',
-                        analyticsStorageConsentWeb: 'Unspecified',
+                        consentMappingSDK: JSON.stringify(consentMap),
+                        adStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                        adUserDataConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                        adPersonalizationConsentSDK: 'Unspecified',
+                        analyticsStorageConsentSDK: 'Unspecified',
                     },
                     reportService.cb,
                     true
@@ -1297,7 +1297,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
+                        consentMappingSDK: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true
@@ -1454,11 +1454,11 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
-                        adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentWeb: 'Granted',
-                        analyticsStorageConsentWeb: 'Granted',
+                        consentMappingSDK: JSON.stringify(consentMap),
+                        adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                        adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                        adStorageConsentSDK: 'Granted',
+                        analyticsStorageConsentSDK: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1619,7 +1619,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb: JSON.stringify(consentMap),
+                        consentMappingSDK: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1215,6 +1215,7 @@ describe('Adwords forwarder', function () {
                     },
                 ];
 
+                // https://go.mparticle.com/work/SQDSDKS-6152
                 window.dataLayer.length.should.eql(1);
                 window.dataLayer[0][0].should.equal('consent');
                 window.dataLayer[0][1].should.equal('default');

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1758,7 +1758,7 @@ describe('Adwords forwarder', function () {
 
                 var expectedDataLayerBefore = [
                     'consent',
-                    'update',
+                    'default',
                     {
                         ad_user_data: 'granted',
                         ad_personalization: 'denied',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1233,10 +1233,10 @@ describe('Adwords forwarder', function () {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
                         consentMappingWeb: JSON.stringify(consentMap),
-                        adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsent: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentWeb: 'Granted',
-                        analyticsStorageConsentWeb: 'Granted',
+                        defaultAdPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
+                        defaultAdUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                        defaultAdStorageConsentWeb: 'Granted',
+                        defaultAnalyticsStorageConsentWeb: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1267,10 +1267,10 @@ describe('Adwords forwarder', function () {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
                         consentMappingWeb: JSON.stringify(consentMap),
-                        adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
-                        adUserDataConsent: 'Unspecified', // Will be overriden by User Consent State
-                        adPersonalizationConsent: 'Unspecified',
-                        analyticsStorageConsentWeb: 'Unspecified',
+                        defaultAdStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                        defaultAdUserDataConsent: 'Unspecified', // Will be overriden by User Consent State
+                        defaultAdPersonalizationConsent: 'Unspecified',
+                        defaultAnalyticsStorageConsentWeb: 'Unspecified',
                     },
                     reportService.cb,
                     true
@@ -1456,10 +1456,10 @@ describe('Adwords forwarder', function () {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
                         consentMappingWeb: JSON.stringify(consentMap),
-                        adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
-                        adUserDataConsent: 'Granted', // Will be overriden by User Consent State
-                        adStorageConsentWeb: 'Granted',
-                        analyticsStorageConsentWeb: 'Granted',
+                        defaultAdPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
+                        defaultAdUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                        defaultAdStorageConsentWeb: 'Granted',
+                        defaultAnalyticsStorageConsentWeb: 'Granted',
                     },
                     reportService.cb,
                     true
@@ -1747,10 +1747,10 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        adUserDataConsent: 'Granted',
-                        adPersonalizationConsent: 'Denied',
-                        adStorageConsentWeb: 'Granted',
-                        analyticsStorageConsentWeb: 'Denied',
+                        defaultAdUserDataConsent: 'Granted',
+                        defaultAdPersonalizationConsent: 'Denied',
+                        defaultAdStorageConsentWeb: 'Granted',
+                        defaultAnalyticsStorageConsentWeb: 'Denied',
                     },
                     reportService.cb,
                     true

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1614,7 +1614,7 @@ describe('Adwords forwarder', function () {
                 done();
             });
 
-            it('should NOT construct a Consent State Update Payload if consent DOES NOT changes', function (done) {
+            it('should NOT construct a Consent State Update Payload if consent DOES NOT change', function (done) {
                 mParticle.forwarder.init(
                     {
                         conversionId: 'AW-123123123',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1713,50 +1713,6 @@ describe('Adwords forwarder', function () {
                                     Timestamp: Date.now(),
                                     Document: 'test_consent',
                                 },
-                            };
-                        },
-
-                        getCCPAConsentState: function () {
-                            return {
-                                data_sale_opt_out: {
-                                    Consented: false,
-                                    Timestamp: Date.now(),
-                                    Document: 'data_sale_opt_out',
-                                },
-                            };
-                        },
-                    },
-                });
-
-                window.dataLayer.length.should.eql(0);
-
-                mParticle.forwarder.process({
-                    EventName: 'Homepage',
-                    EventDataType: MessageType.PageEvent,
-                    EventCategory: EventType.Navigation,
-                    EventAttributes: {
-                        showcase: 'something',
-                        test: 'thisoneshouldgetmapped',
-                        mp: 'rock',
-                    },
-                    ConsentState: {
-                        getGDPRConsentState: function () {
-                            return {
-                                some_consent: {
-                                    Consented: true,
-                                    Timestamp: Date.now(),
-                                    Document: 'some_consent',
-                                },
-                                ignored_consent: {
-                                    Consented: false,
-                                    Timestamp: Date.now(),
-                                    Document: 'ignored_consent',
-                                },
-                                test_consent: {
-                                    Consented: true,
-                                    Timestamp: Date.now(),
-                                    Document: 'test_consent',
-                                },
                                 other_test_consent: {
                                     Consented: true,
                                     Timestamp: Date.now(),

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1132,6 +1132,33 @@ describe('Adwords forwarder', function () {
         });
 
         describe('Consent State', function () {
+            var consentMap = [
+                {
+                    jsmap: null,
+                    map: 'some_consent',
+                    maptype: 'ConsentPurposes',
+                    value: 'ad_user_data',
+                },
+                {
+                    jsmap: null,
+                    map: 'storage_consent',
+                    maptype: 'ConsentPurposes',
+                    value: 'analytics_storage',
+                },
+                {
+                    jsmap: null,
+                    map: 'other_test_consent',
+                    maptype: 'ConsentPurposes',
+                    value: 'ad_storage',
+                },
+                {
+                    jsmap: null,
+                    map: 'test_consent',
+                    maptype: 'ConsentPurposes',
+                    value: 'ad_personalization',
+                },
+            ];
+
             beforeEach(function () {
                 window.dataLayer = [];
                 window.gtag = function () {
@@ -1173,8 +1200,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true
@@ -1201,8 +1227,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                         adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
                         adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
                         adStorageConsentWeb: 'Granted',
@@ -1236,8 +1261,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                         adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
                         adUserDataConsentWeb: 'Unspecified', // Will be overriden by User Consent State
                         adPersonalizationConsentWeb: 'Unspecified',
@@ -1269,8 +1293,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true
@@ -1427,8 +1450,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                         adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
                         adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
                         adStorageConsentWeb: 'Granted',
@@ -1593,8 +1615,7 @@ describe('Adwords forwarder', function () {
                     {
                         conversionId: 'AW-123123123',
                         enableGtag: 'True',
-                        consentMappingWeb:
-                            '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        consentMappingWeb: JSON.stringify(consentMap),
                     },
                     reportService.cb,
                     true


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds a check to initForwarder and processEvents so that if the consent state changes, we alert Google via their `gtag` as per their [Consent Mode Documention](https://developers.google.com/tag-platform/security/guides/consent)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Set up Consent Mapping and Privacy Configuration via the mParticle UI
 - Using our [Data Privacy Controls] instructions, toggle some of the mapped consent states via the developer console
 - Verify that mapped events appear in `window.dataLayer` via browser developer console as updates with updated values

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6133
